### PR TITLE
Start Release 1.2.0 (based on jqassistant 1.1.0)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ subprojects {
     apply plugin: 'org.asciidoctor.gradle.asciidoctor'
     apply plugin: 'com.github.jruby-gradle.base'
 
-    project.version = '1.1.0-SNAPSHOT'
+    project.version = project.parent.version
     sourceCompatibility = 1.7
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,9 @@ apply plugin: 'maven'
 apply plugin: 'org.asciidoctor.gradle.asciidoctor'
 apply plugin: 'com.github.jruby-gradle.base'
 
-project.ext["jqaversion"] = "1.0.0"
+project.ext["jqaversion"] = "1.1.0"
 project.group = 'de.kontext-e.jqassistant.plugin'
-project.version = '1.1.0-SNAPSHOT'
+project.version = '1.2.0-SNAPSHOT'
 
 buildscript {
   repositories {


### PR DESCRIPTION
I have just upgraded to the latest jqassistant release (1.1.0) and therefore started a new semver id (1.2.0-SNAPSHOT)